### PR TITLE
Issue 18 Implement Access token storage

### DIFF
--- a/data/data-jmap/pom.xml
+++ b/data/data-jmap/pom.xml
@@ -28,10 +28,10 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>james-server-jmap</artifactId>
+    <artifactId>james-server-data-jmap</artifactId>
     <packaging>jar</packaging>
 
-    <name>Apache James :: Server :: JMAP</name>
+    <name>Apache James :: Server :: Data :: JMAP</name>
 
     <profiles>
         <profile>
@@ -175,60 +175,15 @@
             <dependencies>
                 <dependency>
                     <groupId>org.apache.james</groupId>
-                    <artifactId>james-server-core</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>org.apache.james</groupId>
                     <artifactId>james-server-data-api</artifactId>
                 </dependency>
                 <dependency>
-                    <groupId>org.apache.james</groupId>
-                    <artifactId>james-server-data-jmap</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>org.apache.james</groupId>
-                    <artifactId>james-server-filesystem-api</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>org.apache.james</groupId>
-                    <artifactId>james-server-lifecycle-api</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>org.apache.james</groupId>
-                    <artifactId>james-server-protocols-library</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>org.apache.james</groupId>
-                    <artifactId>james-server-queue-api</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>org.apache.james</groupId>
-                    <artifactId>james-server-util</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>commons-codec</groupId>
-                    <artifactId>commons-codec</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                    <version>2.3.3</version>
-                </dependency>
-                <dependency>
-                    <groupId>com.jayway.restassured</groupId>
-                    <artifactId>rest-assured</artifactId>
-                    <version>2.5.0</version>
-                    <scope>test</scope>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-collections4</artifactId>
                 </dependency>
                 <dependency>
                     <groupId>javax.inject</groupId>
                     <artifactId>javax.inject</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>javax.servlet</groupId>
-                    <artifactId>javax.servlet-api</artifactId>
-                    <version>3.0.1</version>
-                    <scope>provided</scope>
                 </dependency>
                 <dependency>
                     <groupId>junit</groupId>
@@ -238,18 +193,6 @@
                 <dependency>
                     <groupId>org.assertj</groupId>
                     <artifactId>assertj-core</artifactId>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-server</artifactId>
-                    <version>9.3.2.v20150730</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-servlet</artifactId>
-                    <version>9.3.2.v20150730</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>

--- a/data/data-jmap/src/main/java/org/apache/james/jmap/api/access/AccessToken.java
+++ b/data/data-jmap/src/main/java/org/apache/james/jmap/api/access/AccessToken.java
@@ -1,0 +1,51 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.api.access;
+
+import java.util.Objects;
+
+public class AccessToken {
+
+    public static AccessToken fromString(String tokenString) {
+        return new AccessToken(tokenString);
+    }
+
+    private final String token;
+
+    private AccessToken(String token) {
+        this.token = token;
+    }
+
+    public String serialize() {
+        return token;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o != null
+            && o instanceof AccessToken
+            && Objects.equals(this.token, ((AccessToken)o).token);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(token);
+    }
+}

--- a/data/data-jmap/src/main/java/org/apache/james/jmap/api/access/AccessTokenRepository.java
+++ b/data/data-jmap/src/main/java/org/apache/james/jmap/api/access/AccessTokenRepository.java
@@ -1,0 +1,32 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.api.access;
+
+import org.apache.james.jmap.api.access.exceptions.AccessTokenAlreadyStored;
+
+public interface AccessTokenRepository {
+
+    void addToken(AccessToken accessToken) throws AccessTokenAlreadyStored;
+
+    void removeToken(AccessToken accessToken);
+
+    boolean verifyToken(AccessToken accessToken);
+
+}

--- a/data/data-jmap/src/main/java/org/apache/james/jmap/api/access/exceptions/AccessTokenAlreadyStored.java
+++ b/data/data-jmap/src/main/java/org/apache/james/jmap/api/access/exceptions/AccessTokenAlreadyStored.java
@@ -1,0 +1,29 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.api.access.exceptions;
+
+import org.apache.james.jmap.api.access.AccessToken;
+
+public class AccessTokenAlreadyStored extends Exception {
+
+    public AccessTokenAlreadyStored(AccessToken token) {
+        super(token.serialize() + " is already stored");
+    }
+}

--- a/data/data-jmap/src/main/java/org/apache/james/jmap/memory/access/MemoryAccessTokenRepository.java
+++ b/data/data-jmap/src/main/java/org/apache/james/jmap/memory/access/MemoryAccessTokenRepository.java
@@ -1,0 +1,67 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.memory.access;
+
+import com.google.common.base.Preconditions;
+import org.apache.commons.collections4.map.PassiveExpiringMap;
+import org.apache.james.jmap.api.access.AccessToken;
+import org.apache.james.jmap.api.access.AccessTokenRepository;
+import org.apache.james.jmap.api.access.exceptions.AccessTokenAlreadyStored;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class MemoryAccessTokenRepository implements AccessTokenRepository {
+
+    private final PassiveExpiringMap<AccessToken, Boolean> tokensExpirationDates;
+
+    @Inject
+    public MemoryAccessTokenRepository(long durationInMilliseconds) {
+        tokensExpirationDates = new PassiveExpiringMap<>(durationInMilliseconds);
+    }
+
+    @Override
+    public void addToken(AccessToken accessToken) throws AccessTokenAlreadyStored{
+        Preconditions.checkNotNull(accessToken);
+        synchronized (tokensExpirationDates) {
+            if (tokensExpirationDates.putIfAbsent(accessToken, true) != null) {
+                throw new AccessTokenAlreadyStored(accessToken);
+            }
+        }
+    }
+
+    @Override
+    public void removeToken(AccessToken accessToken) {
+        Preconditions.checkNotNull(accessToken);
+        synchronized (tokensExpirationDates) {
+            tokensExpirationDates.remove(accessToken);
+        }
+    }
+
+    @Override
+    public boolean verifyToken(AccessToken accessToken) {
+        Preconditions.checkNotNull(accessToken);
+        synchronized (tokensExpirationDates) {
+            return tokensExpirationDates.containsKey(accessToken);
+        }
+    }
+
+}

--- a/data/data-jmap/src/test/java/org/apache/james/jmap/memory/access/MemoryAccessTokenRepositoryTest.java
+++ b/data/data-jmap/src/test/java/org/apache/james/jmap/memory/access/MemoryAccessTokenRepositoryTest.java
@@ -1,0 +1,92 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.memory.access;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import org.apache.james.jmap.api.access.AccessToken;
+import org.apache.james.jmap.api.access.exceptions.AccessTokenAlreadyStored;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MemoryAccessTokenRepositoryTest {
+
+    private static final AccessToken TOKEN = AccessToken.fromString("TOKEN");
+    private static final int TTL_IN_MS = 100;
+
+    private MemoryAccessTokenRepository accessTokenRepository;
+
+    @Before
+    public void setUp() {
+        accessTokenRepository = new MemoryAccessTokenRepository(TTL_IN_MS);
+    }
+
+    @Test
+    public void validTokenMustWork() throws Exception {
+        accessTokenRepository.addToken(TOKEN);
+        assertThat(accessTokenRepository.verifyToken(TOKEN)).isTrue();
+    }
+
+    @Test
+    public void nonStoredTokensMustBeInvalid() throws Exception {
+        assertThat(accessTokenRepository.verifyToken(TOKEN)).isFalse();
+    }
+
+    @Test
+    public void removedTokensMustBeInvalid() throws Exception {
+        accessTokenRepository.addToken(TOKEN);
+        accessTokenRepository.removeToken(TOKEN);
+        assertThat(accessTokenRepository.verifyToken(TOKEN)).isFalse();
+    }
+
+    @Test(expected = AccessTokenAlreadyStored.class)
+    public void addTokenMustThrowWhenTokenIsAlreadyStored() throws Exception {
+        try {
+            accessTokenRepository.addToken(TOKEN);
+        } catch(Exception e) {
+            fail("Exception caught", e);
+        }
+        accessTokenRepository.addToken(TOKEN);
+    }
+
+    @Test
+    public void outDatedTokenMustBeInvalid() throws Exception {
+        accessTokenRepository.addToken(TOKEN);
+        Thread.sleep(200);
+        assertThat(accessTokenRepository.verifyToken(TOKEN)).isFalse();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void addTokenMustThrowWhenTokenIsNull() throws Exception {
+        accessTokenRepository.addToken(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void removeTokenTokenMustThrowWhenTokenIsNull() throws Exception {
+        accessTokenRepository.removeToken(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void verifyTokenTokenMustThrowWhenTokenIsNull() throws Exception {
+        accessTokenRepository.verifyToken(null);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
         <module>data/data-jpa</module>
         <module>data/data-jcr</module>
         <module>data/data-jdbc</module>
+        <module>data/data-jmap</module>
         <module>data/data-file</module>
         <module>data/data-ldap</module>
         <module>data/data-hbase</module>
@@ -461,6 +462,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.james</groupId>
+                <artifactId>james-server-data-jmap</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.james</groupId>
                 <artifactId>james-server-data-jcr</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -726,6 +732,11 @@
                 <groupId>commons-collections</groupId>
                 <artifactId>commons-collections</artifactId>
                 <version>${commons-collections.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-collections4</artifactId>
+                <version>4.0</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/IMAPServerFactory.java
+++ b/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/IMAPServerFactory.java
@@ -29,20 +29,21 @@ import org.apache.james.filesystem.api.FileSystem;
 import org.apache.james.imap.api.process.ImapProcessor;
 import org.apache.james.imap.decode.ImapDecoder;
 import org.apache.james.imap.encode.ImapEncoder;
+import org.apache.james.protocols.lib.KeystoreLoader;
 import org.apache.james.protocols.lib.netty.AbstractConfigurableAsyncServer;
 import org.apache.james.protocols.lib.netty.AbstractServerFactory;
 import org.slf4j.Logger;
 
 public class IMAPServerFactory extends AbstractServerFactory {
 
-    private FileSystem fileSystem;
+    private KeystoreLoader keystoreLoader;
     private ImapDecoder decoder;
     private ImapEncoder encoder;
     private ImapProcessor processor;
-    
+
     @Inject
-    public final void setFileSystem(@Named("filesystem") FileSystem filesystem) {
-        this.fileSystem = filesystem;
+    public void setKeystoreLoader(KeystoreLoader keystoreLoader) {
+        this.keystoreLoader = keystoreLoader;
     }
 
     @Inject
@@ -74,7 +75,7 @@ public class IMAPServerFactory extends AbstractServerFactory {
         for (HierarchicalConfiguration serverConfig: configs) {
             IMAPServer server = createServer();
             server.setLog(log);
-            server.setFileSystem(fileSystem);
+            server.setKeystoreLoader(keystoreLoader);
             server.setImapDecoder(decoder);
             server.setImapEncoder(encoder);
             server.setImapProcessor(processor);

--- a/protocols/protocols-library/src/main/java/org/apache/james/protocols/lib/netty/AbstractConfigurableAsyncServer.java
+++ b/protocols/protocols-library/src/main/java/org/apache/james/protocols/lib/netty/AbstractConfigurableAsyncServer.java
@@ -116,7 +116,7 @@ public abstract class AbstractConfigurableAsyncServer extends AbstractAsyncServe
     private MBeanServer mbeanServer;
 
     @Inject
-    public final void setFileSystem(KeystoreLoader keystoreLoader) {
+    public final void setKeystoreLoader(KeystoreLoader keystoreLoader) {
         this.keystoreLoader = keystoreLoader;
     }
 

--- a/protocols/protocols-lmtp/src/main/java/org/apache/james/lmtpserver/netty/LMTPServerFactory.java
+++ b/protocols/protocols-lmtp/src/main/java/org/apache/james/lmtpserver/netty/LMTPServerFactory.java
@@ -25,6 +25,7 @@ import javax.inject.Inject;
 
 import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.james.filesystem.api.FileSystem;
+import org.apache.james.protocols.lib.KeystoreLoader;
 import org.apache.james.protocols.lib.handler.ProtocolHandlerLoader;
 import org.apache.james.protocols.lib.netty.AbstractConfigurableAsyncServer;
 import org.apache.james.protocols.lib.netty.AbstractServerFactory;
@@ -33,7 +34,7 @@ import org.slf4j.Logger;
 public class LMTPServerFactory extends AbstractServerFactory{
 
     private ProtocolHandlerLoader loader;
-    private FileSystem fileSystem;
+    private KeystoreLoader keystoreLoader;
 
     @Inject
     public void setProtocolHandlerLoader(ProtocolHandlerLoader loader) {
@@ -41,8 +42,8 @@ public class LMTPServerFactory extends AbstractServerFactory{
     }
     
     @Inject
-    public final void setFileSystem(FileSystem filesystem) {
-        this.fileSystem = filesystem;
+    public void setKeystoreLoader(KeystoreLoader keystoreLoader) {
+        this.keystoreLoader = keystoreLoader;
     }
 
     protected LMTPServer createServer() {
@@ -57,7 +58,7 @@ public class LMTPServerFactory extends AbstractServerFactory{
         
         for (HierarchicalConfiguration serverConfig: configs) {
             LMTPServer server = createServer();
-            server.setFileSystem(fileSystem);
+            server.setKeystoreLoader(keystoreLoader);
             server.setProtocolHandlerLoader(loader);
             server.setLog(log);
             server.configure(serverConfig);

--- a/protocols/protocols-pop3/src/main/java/org/apache/james/pop3server/netty/POP3ServerFactory.java
+++ b/protocols/protocols-pop3/src/main/java/org/apache/james/pop3server/netty/POP3ServerFactory.java
@@ -7,6 +7,7 @@ import javax.inject.Inject;
 
 import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.james.filesystem.api.FileSystem;
+import org.apache.james.protocols.lib.KeystoreLoader;
 import org.apache.james.protocols.lib.handler.ProtocolHandlerLoader;
 import org.apache.james.protocols.lib.netty.AbstractConfigurableAsyncServer;
 import org.apache.james.protocols.lib.netty.AbstractServerFactory;
@@ -15,7 +16,7 @@ import org.slf4j.Logger;
 public class POP3ServerFactory extends AbstractServerFactory{
 
     private ProtocolHandlerLoader loader;
-    private FileSystem fileSystem;
+    private KeystoreLoader keystoreLoader;
     
     @Inject
     public void setProtocolHandlerLoader(ProtocolHandlerLoader loader) {
@@ -23,8 +24,8 @@ public class POP3ServerFactory extends AbstractServerFactory{
     }
 
     @Inject
-    public final void setFileSystem(FileSystem filesystem) {
-        this.fileSystem = filesystem;
+    public final void setKeystoreLoader(KeystoreLoader keystoreLoader) {
+        this.keystoreLoader = keystoreLoader;
     }
 
     protected POP3Server createServer() {
@@ -42,7 +43,7 @@ public class POP3ServerFactory extends AbstractServerFactory{
             POP3Server server = createServer();
             server.setProtocolHandlerLoader(loader);
             server.setLog(log);
-            server.setFileSystem(fileSystem);
+            server.setKeystoreLoader(keystoreLoader);
             server.configure(serverConfig);
             servers.add(server);
         }

--- a/protocols/protocols-pop3/src/test/java/org/apache/james/pop3server/POP3ServerTest.java
+++ b/protocols/protocols-pop3/src/test/java/org/apache/james/pop3server/POP3ServerTest.java
@@ -51,6 +51,7 @@ import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.store.Authenticator;
 import org.apache.james.mailbox.store.StoreMailboxManager;
 import org.apache.james.pop3server.netty.POP3Server;
+import org.apache.james.protocols.lib.KeystoreLoader;
 import org.apache.james.protocols.lib.POP3BeforeSMTPHelper;
 import org.apache.james.protocols.lib.PortUtil;
 import org.apache.james.protocols.lib.mock.MockProtocolHandlerLoader;
@@ -688,8 +689,11 @@ public class POP3ServerTest {
     }
 
     protected void setUpPOP3Server() {
+        KeystoreLoader keystoreLoader = new KeystoreLoader();
+        keystoreLoader.setFileSystem(fileSystem);
+
         pop3Server = createPOP3Server();
-        pop3Server.setFileSystem(fileSystem);
+        pop3Server.setKeystoreLoader(keystoreLoader);
         pop3Server.setProtocolHandlerLoader(protocolHandlerChain);
     
         Logger log = LoggerFactory.getLogger("Mock");

--- a/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/netty/SMTPServerFactory.java
+++ b/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/netty/SMTPServerFactory.java
@@ -26,7 +26,7 @@ import javax.inject.Inject;
 
 import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.james.dnsservice.api.DNSService;
-import org.apache.james.filesystem.api.FileSystem;
+import org.apache.james.protocols.lib.KeystoreLoader;
 import org.apache.james.protocols.lib.handler.ProtocolHandlerLoader;
 import org.apache.james.protocols.lib.netty.AbstractConfigurableAsyncServer;
 import org.apache.james.protocols.lib.netty.AbstractServerFactory;
@@ -36,7 +36,7 @@ public class SMTPServerFactory extends AbstractServerFactory {
 
     private DNSService dns;
     private ProtocolHandlerLoader loader;
-    private FileSystem fileSystem;
+    private KeystoreLoader keystoreLoader;
 
     @Inject
     public void setDnsService(DNSService dns) {
@@ -49,8 +49,8 @@ public class SMTPServerFactory extends AbstractServerFactory {
     }
 
     @Inject
-    public final void setFileSystem(FileSystem filesystem) {
-        this.fileSystem = filesystem;
+    public final void setFileSystem(KeystoreLoader keystoreLoader) {
+        this.keystoreLoader = keystoreLoader;
     }
 
     protected SMTPServer createServer() {
@@ -69,7 +69,7 @@ public class SMTPServerFactory extends AbstractServerFactory {
             server.setDnsService(dns);
             server.setProtocolHandlerLoader(loader);
             server.setLog(log);
-            server.setFileSystem(fileSystem);
+            server.setKeystoreLoader(keystoreLoader);
             server.configure(serverConfig);
             servers.add(server);
         }

--- a/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPServerTest.java
+++ b/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPServerTest.java
@@ -42,6 +42,7 @@ import org.apache.james.dnsservice.api.DNSService;
 import org.apache.james.domainlist.api.mock.SimpleDomainList;
 import org.apache.james.filesystem.api.mock.MockFileSystem;
 import org.apache.james.mailrepository.mock.MockMailRepositoryStore;
+import org.apache.james.protocols.lib.KeystoreLoader;
 import org.apache.james.protocols.lib.PortUtil;
 import org.apache.james.protocols.lib.mock.MockProtocolHandlerLoader;
 import org.apache.james.protocols.netty.AbstractChannelPipelineFactory;
@@ -188,13 +189,16 @@ public class SMTPServerTest {
     }
 
     protected void setUpSMTPServer() {
-        
+
+        KeystoreLoader keystoreLoader = new KeystoreLoader();
+        keystoreLoader.setFileSystem(fileSystem);
+
         Logger log = LoggerFactory.getLogger("SMTP");
         // slf4j can't set programmatically any log level. It's just a facade
         // log.setLevel(SimpleLog.LOG_LEVEL_ALL);
         smtpServer = createSMTPServer();
         smtpServer.setDnsService(dnsServer);
-        smtpServer.setFileSystem(fileSystem);
+        smtpServer.setKeystoreLoader(keystoreLoader);
         smtpServer.setProtocolHandlerLoader(chain);
         smtpServer.setLog(log);
 


### PR DESCRIPTION
In this PR : 
 - I added a storage interface for JMAP protocol access token.
 Storage intefaces for servers needs to be in data-api
 I introduced a new project data-jmap as I wanted to use ZoneDateTime in my code.
 
 The in memory implementation is thread safe. The only tricky thing is the expired token removal ( for storage optimization ). Remenber that no one can modify the given map entry until it is removed ( guaranteed by the addToken method ). Not adding two time the same token is a JMAP requirement.