### PR TITLE
James 511

### DIFF
--- a/app/src/main/resources/quota-template.xml
+++ b/app/src/main/resources/quota-template.xml
@@ -85,6 +85,26 @@
          CLI values.
         -->
         <provider>fake</provider>
+        <!--
+        Configuration option for setting max policies for MaxQuotaManager ( message count and byte )
+        -->
+        <!--
+        <defaultMaxMessage>100000</defaultMaxMessage>
+        <defaultMaxStorage>5368709120</defaultMaxStorage>
+        -->
+        <!--
+        Configuration option for setting max values per quota root ( message count and byte )
+        -->
+        <!--
+        <maxMessage>
+            <quotaRoot>#private&amp;btellier@apache.org</quotaRoot>
+            <value>200000</value>
+        </maxMessage>
+        <maxStorage>
+            <quotaRoot>#private&amp;btellier@apache.org</quotaRoot>
+            <value>10737418240</value>
+        </maxStorage>
+        -->
     </maxQuotaManager>
     <quotaManager>
         <!--

--- a/app/src/main/resources/quota-template.xml
+++ b/app/src/main/resources/quota-template.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+ -->
+
+<!--
+   This template file can be used as example for James Server configuration
+   DO NOT USE IT AS SUCH AND ADAPT IT TO YOUR NEEDS
+-->
+
+<!-- See http://james.apache.org/server/3/config.html for usage -->
+
+<!--
+        This configuration file allows you to customize the way quota are handled on this server.
+        You need to rename it in quota.xml so that it gets interpreted by James on startup.
+
+        The different configuration options are detailed here.
+
+        Read RFC-2087 for full details.
+-->
+
+<quota>
+    <!--
+        Quota implementation is based on several components :
+          - QuotaRootResolver : In regard of quota management, mailboxes forms abstract groups called QUOTA ROOT. This
+          component finds to which QUOTA ROOT a mailbox belongs
+          - Current quota manager : Counters for current values : how many messages belongs to this quota root ? Which
+          size ?
+          - Max Quota manager : Sets a maximum value QUOTA ROOT resources can not exceed.
+          - QuotaManager : assemble Current quota manager and Max quota manager.
+          - Listening quota updater : Event system based quota update. On each APPED / COPY /EXPUNGE command, current
+          quotas gets updated.
+    -->
+
+    <quotaRootResolver>
+        <!--
+        Possible value :
+         - default
+        -->
+        <provider>default</provider>
+    </quotaRootResolver>
+    <currentQuotaManager>
+        <!--
+        Possible value for provider :
+         - none : when you use fake as a value for quotaManager's provider
+         - inmemory
+         - cassandra
+
+        The inmemory implementation :
+         - Does not work in a distributed context
+        Note that quota need to be (lazy) re-calculated after each starts
+
+        Cassandra implementation.
+        Non existing quota are considered as null. No cache. It needs to be always enabled, or you might get some
+        quota synchronisation issues.
+         -->
+        <provider>none</provider>
+    </currentQuotaManager>
+    <maxQuotaManager>
+        <!--
+        This component is exposed to the CLI for quota administration tasks.
+
+        Possible value are :
+         - fake : will always return UNLIMITED. Throws on modifications.
+         - fixed : all QUOTA ROOT get the same upper bound for their quotas.
+         - inmemory : allows you to define QUOTA ROOT specific limits, backed with a fixed policy. It does not
+         work in a distributed context.
+         - cassandra : Same thing than inmemory but backed on cassandra. Works on a distributed context. Note that using
+         the default* configuration options and the CLI to set default options is dangerous as server startup might override
+         CLI values.
+        -->
+        <provider>fake</provider>
+    </maxQuotaManager>
+    <quotaManager>
+        <!--
+        The QuotaManager you use.
+
+        Possible values are :
+         - fake : returns only UNKNOWN/UNLIMITED quotas
+         - store : returns quotas using a CurrentQuotaManager and a MaxQuotaManager
+        -->
+        <provider>fake</provider>
+    </quotaManager>
+    <updates>
+        <!--
+        This defines the way your quotas gets updated.
+        Possible values are :
+         - fake
+         - event
+        -->
+        <provider>fake</provider>
+    </updates>
+</quota>

--- a/container/cli/src/main/java/org/apache/james/cli/ServerCmd.java
+++ b/container/cli/src/main/java/org/apache/james/cli/ServerCmd.java
@@ -232,10 +232,10 @@ public class ServerCmd {
             System.out.println("Storage space allowed for Quota Root "
                 + arguments[1]
                 + " : "
-                + FileUtils.byteCountToDisplaySize(probe.getMaxStorage(arguments[1])));
+                + formatStorageValue(probe.getMaxStorage(arguments[1])));
             break;
         case GETMAXMESSAGECOUNTQUOTA:
-            System.out.println("Message count allowed for Quota Root " + arguments[1] + " : " + probe.getMaxMessageCount(arguments[1]));
+            System.out.println("Message count allowed for Quota Root " + arguments[1] + " : " + formatMessageValue(probe.getMaxMessageCount(arguments[1])));
             break;
         case SETMAXSTORAGEQUOTA:
             probe.setMaxStorage(arguments[1], ValueWithUnit.parse(arguments[2]).getConvertedValue());
@@ -250,10 +250,10 @@ public class ServerCmd {
             probe.setDefaultMaxMessageCount(Long.parseLong(arguments[1]));
             break;
         case GETDEFAULTMAXSTORAGEQUOTA:
-            System.out.println("Default Maximum Storage Quota : " + FileUtils.byteCountToDisplaySize(probe.getDefaultMaxStorage()));
+            System.out.println("Default Maximum Storage Quota : " + formatStorageValue(probe.getDefaultMaxStorage()));
             break;
         case GETDEFAULTMAXMESSAGECOUNTQUOTA:
-            System.out.println("Default Maximum message count Quota : " + probe.getDefaultMaxMessageCount());
+            System.out.println("Default Maximum message count Quota : " + formatMessageValue(probe.getDefaultMaxMessageCount()));
             break;
         default:
             throw new UnrecognizedCommandException(cmdType.getCommand());
@@ -272,14 +272,35 @@ public class ServerCmd {
     private void printStorageQuota(String quotaRootString, Quota quota) {
         System.out.println(String.format("Storage quota for %s is : %s / %s",
             quotaRootString,
-            FileUtils.byteCountToDisplaySize(quota.getUsed()),
-            FileUtils.byteCountToDisplaySize(quota.getMax())));
+            formatStorageValue(quota.getUsed()),
+            formatStorageValue(quota.getMax())));
     }
+
     private void printMessageQuota(String quotaRootString, Quota quota) {
-        System.out.println(String.format("Message count quota for %s is : %d / %d",
+        System.out.println(String.format("Message count quota for %s is : %s / %s",
             quotaRootString,
-            quota.getUsed(),
-            quota.getMax()));
+            formatMessageValue(quota.getUsed()),
+            formatMessageValue(quota.getMax())));
+    }
+
+    private String formatStorageValue(long value) {
+        if (value == Quota.UNKNOWN) {
+            return ValueWithUnit.UNKNOWN;
+        }
+        if (value == Quota.UNLIMITED) {
+            return ValueWithUnit.UNLIMITED;
+        }
+        return FileUtils.byteCountToDisplaySize(value);
+    }
+
+    private String formatMessageValue(long value) {
+        if (value == Quota.UNKNOWN) {
+            return ValueWithUnit.UNKNOWN;
+        }
+        if (value == Quota.UNLIMITED) {
+            return ValueWithUnit.UNLIMITED;
+        }
+        return String.valueOf(value);
     }
 
     private void print(Map<String, Collection<String>> map, PrintStream out) {

--- a/container/cli/src/main/java/org/apache/james/cli/ServerCmd.java
+++ b/container/cli/src/main/java/org/apache/james/cli/ServerCmd.java
@@ -27,6 +27,7 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.PosixParser;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.time.StopWatch;
 import org.apache.james.cli.exceptions.InvalidArgumentNumberException;
 import org.apache.james.cli.exceptions.InvalidPortException;
@@ -36,6 +37,8 @@ import org.apache.james.cli.exceptions.UnrecognizedCommandException;
 import org.apache.james.cli.probe.ServerProbe;
 import org.apache.james.cli.probe.impl.JmxServerProbe;
 import org.apache.james.cli.type.CmdType;
+import org.apache.james.cli.utils.ValueWithUnit;
+import org.apache.james.mailbox.model.Quota;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -216,6 +219,42 @@ public class ServerCmd {
         case DELETEMAILBOX:
             probe.deleteMailbox(arguments[1], arguments[2], arguments[3]);
             break;
+        case GETSTORAGEQUOTA:
+            printStorageQuota(arguments[1], probe.getStorageQuota(arguments[1]));
+            break;
+        case GETMESSAGECOUNTQUOTA:
+            printMessageQuota(arguments[1], probe.getMessageCountQuota(arguments[1]));
+            break;
+        case GETQUOTAROOT:
+            System.out.println("Quota Root : " + probe.getQuotaRoot(arguments[1], arguments[2], arguments[3]).getValue());
+            break;
+        case GETMAXSTORAGEQUOTA:
+            System.out.println("Storage space allowed for Quota Root "
+                + arguments[1]
+                + " : "
+                + FileUtils.byteCountToDisplaySize(probe.getMaxStorage(arguments[1])));
+            break;
+        case GETMAXMESSAGECOUNTQUOTA:
+            System.out.println("Message count allowed for Quota Root " + arguments[1] + " : " + probe.getMaxMessageCount(arguments[1]));
+            break;
+        case SETMAXSTORAGEQUOTA:
+            probe.setMaxStorage(arguments[1], ValueWithUnit.parse(arguments[2]).getConvertedValue());
+            break;
+        case SETMAXMESSAGECOUNTQUOTA:
+            probe.setMaxMessageCount(arguments[1], Long.parseLong(arguments[2]));
+            break;
+        case SETDEFAULTMAXSTORAGEQUOTA:
+            probe.setDefaultMaxStorage(ValueWithUnit.parse(arguments[1]).getConvertedValue());
+            break;
+        case SETDEFAULTMAXMESSAGECOUNTQUOTA:
+            probe.setDefaultMaxMessageCount(Long.parseLong(arguments[1]));
+            break;
+        case GETDEFAULTMAXSTORAGEQUOTA:
+            System.out.println("Default Maximum Storage Quota : " + FileUtils.byteCountToDisplaySize(probe.getDefaultMaxStorage()));
+            break;
+        case GETDEFAULTMAXMESSAGECOUNTQUOTA:
+            System.out.println("Default Maximum message count Quota : " + probe.getDefaultMaxMessageCount());
+            break;
         default:
             throw new UnrecognizedCommandException(cmdType.getCommand());
         }
@@ -228,6 +267,19 @@ public class ServerCmd {
             }
             out.println(Joiner.on('\n').join(data));
         }
+    }
+
+    private void printStorageQuota(String quotaRootString, Quota quota) {
+        System.out.println(String.format("Storage quota for %s is : %s / %s",
+            quotaRootString,
+            FileUtils.byteCountToDisplaySize(quota.getUsed()),
+            FileUtils.byteCountToDisplaySize(quota.getMax())));
+    }
+    private void printMessageQuota(String quotaRootString, Quota quota) {
+        System.out.println(String.format("Message count quota for %s is : %d / %d",
+            quotaRootString,
+            quota.getUsed(),
+            quota.getMax()));
     }
 
     private void print(Map<String, Collection<String>> map, PrintStream out) {

--- a/container/cli/src/main/java/org/apache/james/cli/probe/ServerProbe.java
+++ b/container/cli/src/main/java/org/apache/james/cli/probe/ServerProbe.java
@@ -18,6 +18,10 @@
  ****************************************************************/
 package org.apache.james.cli.probe;
 
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.Quota;
+import org.apache.james.mailbox.model.QuotaRoot;
+
 import java.io.Closeable;
 import java.util.Collection;
 import java.util.Map;
@@ -217,4 +221,26 @@ public interface ServerProbe extends Closeable {
      * @param name Name of the mailbox to delete
      */
     void deleteMailbox(String namespace, String user, String name);
+
+    QuotaRoot getQuotaRoot(String namespace, String user, String name) throws MailboxException;
+
+    Quota getMessageCountQuota(String quotaRoot) throws MailboxException;
+
+    Quota getStorageQuota(String quotaRoot) throws MailboxException;
+
+    long getMaxMessageCount(String quotaRoot) throws MailboxException;
+
+    long getMaxStorage(String quotaRoot) throws MailboxException;
+
+    long getDefaultMaxMessageCount() throws MailboxException;
+
+    long getDefaultMaxStorage() throws MailboxException;
+
+    void setMaxMessageCount(String quotaRoot, long maxMessageCount) throws MailboxException;
+
+    void setMaxStorage(String quotaRoot, long maxSize) throws MailboxException;
+
+    void setDefaultMaxMessageCount(long maxDefaultMessageCount) throws MailboxException;
+
+    void setDefaultMaxStorage(long maxDefaultSize) throws MailboxException;
 }

--- a/container/cli/src/main/java/org/apache/james/cli/probe/impl/JmxServerProbe.java
+++ b/container/cli/src/main/java/org/apache/james/cli/probe/impl/JmxServerProbe.java
@@ -19,9 +19,13 @@
 package org.apache.james.cli.probe.impl;
 
 import org.apache.james.adapter.mailbox.MailboxManagerManagementMBean;
+import org.apache.james.adapter.mailbox.QuotaManagementMBean;
 import org.apache.james.cli.probe.ServerProbe;
 import org.apache.james.container.spring.mailbox.MailboxCopierManagementMBean;
 import org.apache.james.domainlist.api.DomainListManagementMBean;
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.Quota;
+import org.apache.james.mailbox.model.QuotaRoot;
 import org.apache.james.rrt.api.RecipientRewriteTableManagementMBean;
 import org.apache.james.user.api.UsersRepositoryManagementMBean;
 
@@ -44,6 +48,7 @@ public class JmxServerProbe implements ServerProbe {
     private final static String USERSREPOSITORY_OBJECT_NAME = "org.apache.james:type=component,name=usersrepository";
     private final static String MAILBOXCOPIER_OBJECT_NAME = "org.apache.james:type=component,name=mailboxcopier";
     private final static String MAILBOXMANAGER_OBJECT_NAME = "org.apache.james:type=component,name=mailboxmanagerbean";
+    private final static String QUOTAMANAGER_OBJECT_NAME = "org.apache.james:type=component,name=quotamanagerbean";
 
     private JMXConnector jmxc;
     
@@ -52,6 +57,7 @@ public class JmxServerProbe implements ServerProbe {
     private UsersRepositoryManagementMBean usersRepositoryProxy;
     private MailboxCopierManagementMBean mailboxCopierManagement;
     private MailboxManagerManagementMBean mailboxManagerManagement;
+    private QuotaManagementMBean quotaManagement;
 
     private static final String fmtUrl = "service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi";
     private static final int defaultPort = 9999;
@@ -109,6 +115,9 @@ public class JmxServerProbe implements ServerProbe {
             name = new ObjectName(MAILBOXMANAGER_OBJECT_NAME);
             mailboxManagerManagement = MBeanServerInvocationHandler.newProxyInstance(
                     mbeanServerConn, name, MailboxManagerManagementMBean.class, true);
+            name = new ObjectName(QUOTAMANAGER_OBJECT_NAME);
+            quotaManagement = MBeanServerInvocationHandler.newProxyInstance(
+                    mbeanServerConn, name, QuotaManagementMBean.class, true);
         } catch (MalformedObjectNameException e) {
             throw new RuntimeException("Invalid ObjectName? Please report this as a bug.", e);
         }
@@ -212,5 +221,60 @@ public class JmxServerProbe implements ServerProbe {
     @Override
     public void deleteMailbox(String namespace, String user, String name) {
         mailboxManagerManagement.deleteMailbox(namespace, user, name);
+    }
+
+    @Override
+    public QuotaRoot getQuotaRoot(String namespace, String user, String name) throws MailboxException {
+        return quotaManagement.getQuotaRoot(namespace, user, name);
+    }
+
+    @Override
+    public Quota getMessageCountQuota(String quotaRoot) throws MailboxException {
+        return quotaManagement.getMessageCountQuota(quotaRoot);
+    }
+
+    @Override
+    public Quota getStorageQuota(String quotaRoot) throws MailboxException {
+        return quotaManagement.getStorageQuota(quotaRoot);
+    }
+
+    @Override
+    public long getMaxMessageCount(String quotaRoot) throws MailboxException {
+        return quotaManagement.getMaxMessageCount(quotaRoot);
+    }
+
+    @Override
+    public long getMaxStorage(String quotaRoot) throws MailboxException {
+        return quotaManagement.getMaxStorage(quotaRoot);
+    }
+
+    @Override
+    public long getDefaultMaxMessageCount() throws MailboxException {
+        return quotaManagement.getDefaultMaxMessageCount();
+    }
+
+    @Override
+    public long getDefaultMaxStorage() throws MailboxException {
+        return quotaManagement.getDefaultMaxStorage();
+    }
+
+    @Override
+    public void setMaxMessageCount(String quotaRoot, long maxMessageCount) throws MailboxException {
+        quotaManagement.setMaxMessageCount(quotaRoot, maxMessageCount);
+    }
+
+    @Override
+    public void setMaxStorage(String quotaRoot, long maxSize) throws MailboxException {
+        quotaManagement.setMaxStorage(quotaRoot, maxSize);
+    }
+
+    @Override
+    public void setDefaultMaxMessageCount(long maxDefaultMessageCount) throws MailboxException {
+        quotaManagement.setDefaultMaxMessageCount(maxDefaultMessageCount);
+    }
+
+    @Override
+    public void setDefaultMaxStorage(long maxDefaultSize) throws MailboxException {
+        quotaManagement.setDefaultMaxStorage(maxDefaultSize);
     }
 }

--- a/container/cli/src/main/java/org/apache/james/cli/type/CmdType.java
+++ b/container/cli/src/main/java/org/apache/james/cli/type/CmdType.java
@@ -40,7 +40,18 @@ public enum CmdType {
     DELETEUSERMAILBOXES("deleteusermailboxes", "user"),
     CREATEMAILBOX("createmailbox", "namespace", "user", "name"),
     LISTUSERMAILBOXES("listusermailboxes", "user"),
-    DELETEMAILBOX("deletemailbox", "namespace", "user", "name");
+    DELETEMAILBOX("deletemailbox", "namespace", "user", "name"),
+    GETSTORAGEQUOTA("getstoragequota", "quotaroot"),
+    GETMESSAGECOUNTQUOTA("getmessagecountquota", "quotaroot"),
+    GETQUOTAROOT("getquotaroot", "namespace", "user", "name"),
+    GETMAXSTORAGEQUOTA("getmaxstoragequota", "quotaroot"),
+    GETMAXMESSAGECOUNTQUOTA("getmaxmessagecountquota", "quotaroot"),
+    SETMAXSTORAGEQUOTA("setmaxstoragequota", "quotaroot", "max_message_count"),
+    SETMAXMESSAGECOUNTQUOTA("setmaxmessagecountquota", "quotaroot", "max_storage"),
+    SETDEFAULTMAXSTORAGEQUOTA("setdefaultmaxstoragequota", "max_storage"),
+    SETDEFAULTMAXMESSAGECOUNTQUOTA("setdefaultmaxmessagecountquota", "max_message_count"),
+    GETDEFAULTMAXSTORAGEQUOTA("getdefaultmaxstoragequota"),
+    GETDEFAULTMAXMESSAGECOUNTQUOTA("getdefaultmaxmessagecountquota");
 
     private final String command;
     private final String[] arguments;

--- a/container/cli/src/main/java/org/apache/james/cli/type/CmdType.java
+++ b/container/cli/src/main/java/org/apache/james/cli/type/CmdType.java
@@ -22,88 +22,88 @@ package org.apache.james.cli.type;
  * Enumeration of valid command types.
  */
 public enum CmdType {
-	ADDUSER("adduser", "username","password"),
-	REMOVEUSER("removeuser", "username"),
-	LISTUSERS("listusers"),
-	ADDDOMAIN("adddomain", "domainname"),
-	REMOVEDOMAIN("removedomain", "domainname"),
-	CONTAINSDOMAIN("containsdomain", "domainname"),
-	LISTDOMAINS("listdomains"),
-	LISTMAPPINGS("listmappings"),
-	LISTUSERDOMAINMAPPINGS("listuserdomainmappings", "user","domain"),
-	ADDADDRESSMAPPING("addaddressmapping", "user","domain", "fromaddress"),
-	REMOVEADDRESSMAPPING("removeaddressmapping", "user","domain", "fromaddress"),
-	ADDREGEXMAPPING("addregexmapping", "user","domain", "regex"),
-	REMOVEREGEXMAPPING("removeregexmapping", "user","domain", "regex"),
-	SETPASSWORD("setpassword", "username","password"),
-	COPYMAILBOX("copymailbox", "srcbean","dstbean"),
-	DELETEUSERMAILBOXES("deleteusermailboxes", "user"),
-	CREATEMAILBOX("createmailbox", "namespace", "user", "name"),
-	LISTUSERMAILBOXES("listusermailboxes", "user"),
-	DELETEMAILBOX("deletemailbox", "namespace", "user", "name");
+    ADDUSER("adduser", "username","password"),
+    REMOVEUSER("removeuser", "username"),
+    LISTUSERS("listusers"),
+    ADDDOMAIN("adddomain", "domainname"),
+    REMOVEDOMAIN("removedomain", "domainname"),
+    CONTAINSDOMAIN("containsdomain", "domainname"),
+    LISTDOMAINS("listdomains"),
+    LISTMAPPINGS("listmappings"),
+    LISTUSERDOMAINMAPPINGS("listuserdomainmappings", "user","domain"),
+    ADDADDRESSMAPPING("addaddressmapping", "user","domain", "fromaddress"),
+    REMOVEADDRESSMAPPING("removeaddressmapping", "user","domain", "fromaddress"),
+    ADDREGEXMAPPING("addregexmapping", "user","domain", "regex"),
+    REMOVEREGEXMAPPING("removeregexmapping", "user","domain", "regex"),
+    SETPASSWORD("setpassword", "username","password"),
+    COPYMAILBOX("copymailbox", "srcbean","dstbean"),
+    DELETEUSERMAILBOXES("deleteusermailboxes", "user"),
+    CREATEMAILBOX("createmailbox", "namespace", "user", "name"),
+    LISTUSERMAILBOXES("listusermailboxes", "user"),
+    DELETEMAILBOX("deletemailbox", "namespace", "user", "name");
 
-	private final String command;
-	private final String[] arguments;
+    private final String command;
+    private final String[] arguments;
 
-	CmdType(String command, String... arguments) {
-		this.command = command;
-		this.arguments = arguments;
-	}
+    CmdType(String command, String... arguments) {
+        this.command = command;
+        this.arguments = arguments;
+    }
 
-	/**
-	 * Validate that the number of arguments match the passed value.
-	 * 
-	 * @param arguments
-	 *            The number of argument to compare.
-	 * @return true if values match, false otherwise.
-	 */
-	public boolean hasCorrectArguments(int arguments) {
+    /**
+     * Validate that the number of arguments match the passed value.
+     *
+     * @param arguments
+     *            The number of argument to compare.
+     * @return true if values match, false otherwise.
+     */
+    public boolean hasCorrectArguments(int arguments) {
         return this.arguments.length + 1 == arguments;
 
     }
 
-	/**
-	 * Return a CmdType enumeration that matches the passed command.
-	 * 
-	 * @param command
-	 *            The command to use for lookup.
-	 * @return the CmdType enumeration that matches the passed command, or null
-	 *         if not found.
-	 */
-	public static CmdType lookup(String command) {
-		if (command != null) {
-			for (CmdType cmd : values()) {
+    /**
+     * Return a CmdType enumeration that matches the passed command.
+     *
+     * @param command
+     *            The command to use for lookup.
+     * @return the CmdType enumeration that matches the passed command, or null
+     *         if not found.
+     */
+    public static CmdType lookup(String command) {
+        if (command != null) {
+            for (CmdType cmd : values()) {
                 if (cmd.getCommand().equalsIgnoreCase(command)) {
                     return cmd;
                 }
             }
-		}
-		return null;
-	}
+        }
+        return null;
+    }
 
-	/**
-	 * Return the value of command.
-	 * 
-	 * @return the value of command.
-	 */
-	public String getCommand() {
-		return this.command;
-	}
+    /**
+     * Return the value of command.
+     *
+     * @return the value of command.
+     */
+    public String getCommand() {
+        return this.command;
+    }
 
-	/**
-	 * Return the value of arguments.
-	 * 
-	 * @return the value of arguments.
-	 */
-	public int getArgumentCount() {
-		return this.arguments.length + 1;
-	}
+    /**
+     * Return the value of arguments.
+     *
+     * @return the value of arguments.
+     */
+    public int getArgumentCount() {
+        return this.arguments.length + 1;
+    }
 
     public String getUsage() {
-		StringBuilder stringBuilder = new StringBuilder(command);
-		for(String argument : arguments) {
-			stringBuilder.append(" <" + argument + ">");
-		}
+        StringBuilder stringBuilder = new StringBuilder(command);
+        for(String argument : arguments) {
+            stringBuilder.append(" <" + argument + ">");
+        }
         return stringBuilder.toString();
     }
 }

--- a/container/cli/src/main/java/org/apache/james/cli/utils/ValueWithUnit.java
+++ b/container/cli/src/main/java/org/apache/james/cli/utils/ValueWithUnit.java
@@ -1,0 +1,115 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.cli.utils;
+
+/**
+ * This class is an helper for parsing integer input that may contain units.
+ */
+public class ValueWithUnit {
+
+    /**
+     * supported units : B ( 2^0 ), K ( 2^10 ), M ( 2^20 ), G ( 2^30 )
+     * See  RFC822.SIZE
+     */
+    private enum Unit {
+        NoUnit,
+        B,
+        K,
+        M,
+        G
+    }
+
+    private static final long base = 1024;
+
+    Unit unit;
+    Long value;
+
+    private ValueWithUnit(Unit unit, Long value) {
+        this.unit = unit;
+        this.value = value;
+    }
+
+    public static ValueWithUnit parse(String providedLongWithUnitString) throws Exception{
+        char lastChar = providedLongWithUnitString.charAt(providedLongWithUnitString.length()-1);
+        Unit unit = getUnit(lastChar);
+        String argWithoutUnit = removeLastCharIfNeeded(providedLongWithUnitString, unit);
+        return new ValueWithUnit(unit, Long.parseLong(argWithoutUnit));
+    }
+
+    public Unit getUnit() {
+        return unit;
+    }
+
+    public Long getValue() {
+        return value;
+    }
+
+    public long getConvertedValue() {
+        switch (unit) {
+            case G:
+                value *= base;
+            case M:
+                value *= base;
+            case K:
+                value *= base;
+            default:
+                return value;
+        }
+    }
+
+    private static String removeLastCharIfNeeded(String providedLongWithUnitString, Unit unit) {
+        if(unit != Unit.NoUnit) {
+            return providedLongWithUnitString.substring(0, providedLongWithUnitString.length()-1);
+        } else {
+            return providedLongWithUnitString;
+        }
+    }
+
+    private static Unit getUnit(char lastChar) throws Exception{
+        switch(lastChar) {
+            case 'K' :
+            case 'k' :
+                return Unit.K;
+            case 'M' :
+            case 'm' :
+                return Unit.M;
+            case 'G' :
+            case 'g' :
+                return Unit.G;
+            case 'b' :
+            case 'B' :
+                return Unit.B;
+            case '1' :
+            case '2' :
+            case '3' :
+            case '4' :
+            case '5' :
+            case '6' :
+            case '7' :
+            case '8' :
+            case '9' :
+            case '0' :
+                return Unit.NoUnit;
+            default:
+                throw new Exception("No unit corresponding to char : " + lastChar);
+        }
+    }
+
+}

--- a/container/cli/src/main/java/org/apache/james/cli/utils/ValueWithUnit.java
+++ b/container/cli/src/main/java/org/apache/james/cli/utils/ValueWithUnit.java
@@ -19,10 +19,15 @@
 
 package org.apache.james.cli.utils;
 
+import org.apache.james.mailbox.model.Quota;
+
 /**
  * This class is an helper for parsing integer input that may contain units.
  */
 public class ValueWithUnit {
+
+    public static final String UNKNOWN = "UNKNOWN";
+    public static final String UNLIMITED = "UNLIMITED";
 
     /**
      * supported units : B ( 2^0 ), K ( 2^10 ), M ( 2^20 ), G ( 2^30 )
@@ -47,6 +52,12 @@ public class ValueWithUnit {
     }
 
     public static ValueWithUnit parse(String providedLongWithUnitString) throws Exception{
+        if(providedLongWithUnitString.equalsIgnoreCase(UNKNOWN)) {
+            return new ValueWithUnit(Unit.NoUnit, Quota.UNKNOWN);
+        }
+        if(providedLongWithUnitString.equalsIgnoreCase(UNLIMITED)) {
+            return new ValueWithUnit(Unit.NoUnit, Quota.UNLIMITED);
+        }
         char lastChar = providedLongWithUnitString.charAt(providedLongWithUnitString.length()-1);
         Unit unit = getUnit(lastChar);
         String argWithoutUnit = removeLastCharIfNeeded(providedLongWithUnitString, unit);

--- a/container/cli/src/test/java/org/apache/james/cli/ServerCmdTest.java
+++ b/container/cli/src/test/java/org/apache/james/cli/ServerCmdTest.java
@@ -26,7 +26,6 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collection;
 import java.util.HashMap;
 
@@ -38,6 +37,9 @@ import org.apache.james.cli.exceptions.MissingCommandException;
 import org.apache.james.cli.exceptions.UnrecognizedCommandException;
 import org.apache.james.cli.probe.ServerProbe;
 import org.apache.james.cli.type.CmdType;
+import org.apache.james.mailbox.model.Quota;
+import org.apache.james.mailbox.store.quota.QuotaImpl;
+import org.apache.james.mailbox.store.quota.QuotaRootImpl;
 import org.easymock.IMocksControl;
 import org.junit.Before;
 import org.junit.Test;
@@ -327,6 +329,151 @@ public class ServerCmdTest {
         CommandLine commandLine = ServerCmd.parseCommandLine(arguments);
 
         expect(serverProbe.listUserMailboxes(user)).andReturn(new ArrayList<String>());
+
+        control.replay();
+        testee.executeCommandLine(commandLine);
+        control.verify();
+    }
+
+    @Test
+    public void getQuotaRootCommandShouldWork() throws Exception {
+        String namespace = "#private";
+        String user = "user@domain";
+        String name = "INBOX";
+        String[] arguments = { "-h", "127.0.0.1", "-p", "9999", CmdType.GETQUOTAROOT.getCommand(), namespace, user, name};
+        CommandLine commandLine = ServerCmd.parseCommandLine(arguments);
+
+        expect(serverProbe.getQuotaRoot(namespace, user, name)).andReturn(QuotaRootImpl.quotaRoot(namespace + "&" + user));
+
+        control.replay();
+        testee.executeCommandLine(commandLine);
+        control.verify();
+    }
+
+    @Test
+    public void getDefaultMaxMessageCountCommandShouldWork() throws Exception {
+        String[] arguments = { "-h", "127.0.0.1", "-p", "9999", CmdType.GETDEFAULTMAXMESSAGECOUNTQUOTA.getCommand()};
+        CommandLine commandLine = ServerCmd.parseCommandLine(arguments);
+
+        expect(serverProbe.getDefaultMaxMessageCount()).andReturn(1024L * 1024L);
+
+        control.replay();
+        testee.executeCommandLine(commandLine);
+        control.verify();
+    }
+
+    @Test
+    public void getDefaultMaxStorageCommandShouldWork() throws Exception {
+        String[] arguments = { "-h", "127.0.0.1", "-p", "9999", CmdType.GETDEFAULTMAXSTORAGEQUOTA.getCommand()};
+        CommandLine commandLine = ServerCmd.parseCommandLine(arguments);
+
+        expect(serverProbe.getDefaultMaxStorage()).andReturn(1024L * 1024L * 1024L);
+
+        control.replay();
+        testee.executeCommandLine(commandLine);
+        control.verify();
+    }
+
+    @Test
+    public void setDefaultMaxMessageCountCommandShouldWork() throws Exception {
+        String[] arguments = { "-h", "127.0.0.1", "-p", "9999", CmdType.SETDEFAULTMAXMESSAGECOUNTQUOTA.getCommand(), "1054"};
+        CommandLine commandLine = ServerCmd.parseCommandLine(arguments);
+
+       serverProbe.setDefaultMaxMessageCount(1054);
+        expectLastCall();
+
+        control.replay();
+        testee.executeCommandLine(commandLine);
+        control.verify();
+    }
+
+    @Test
+    public void setDefaultMaxStorageCommandShouldWork() throws Exception {
+        String[] arguments = { "-h", "127.0.0.1", "-p", "9999", CmdType.SETDEFAULTMAXSTORAGEQUOTA.getCommand(), "1G"};
+        CommandLine commandLine = ServerCmd.parseCommandLine(arguments);
+
+        serverProbe.setDefaultMaxStorage(1024 * 1024 * 1024);
+        expectLastCall();
+
+        control.replay();
+        testee.executeCommandLine(commandLine);
+        control.verify();
+    }
+
+    @Test
+    public void setMaxMessageCountCommandShouldWork() throws Exception {
+        String quotaroot = "#private&user@domain";
+        String[] arguments = { "-h", "127.0.0.1", "-p", "9999", CmdType.SETMAXMESSAGECOUNTQUOTA.getCommand(), quotaroot, "1000"};
+        CommandLine commandLine = ServerCmd.parseCommandLine(arguments);
+
+        serverProbe.setMaxMessageCount(quotaroot, 1000);
+        expectLastCall();
+
+        control.replay();
+        testee.executeCommandLine(commandLine);
+        control.verify();
+    }
+
+    @Test
+    public void setMaxStorageCommandShouldWork() throws Exception {
+        String quotaroot = "#private&user@domain";
+        String[] arguments = { "-h", "127.0.0.1", "-p", "9999", CmdType.SETMAXSTORAGEQUOTA.getCommand(), quotaroot, "5M"};
+        CommandLine commandLine = ServerCmd.parseCommandLine(arguments);
+
+        serverProbe.setMaxStorage(quotaroot, 5 * 1024 * 1024);
+        expectLastCall();
+
+        control.replay();
+        testee.executeCommandLine(commandLine);
+        control.verify();
+    }
+
+    @Test
+    public void getMaxMessageCountCommandShouldWork() throws Exception {
+        String quotaroot = "#private&user@domain";
+        String[] arguments = { "-h", "127.0.0.1", "-p", "9999", CmdType.GETMAXMESSAGECOUNTQUOTA.getCommand(), quotaroot};
+        CommandLine commandLine = ServerCmd.parseCommandLine(arguments);
+
+        expect(serverProbe.getMaxMessageCount(quotaroot)).andReturn(Quota.UNLIMITED);
+
+        control.replay();
+        testee.executeCommandLine(commandLine);
+        control.verify();
+    }
+
+    @Test
+    public void getMaxStorageQuotaCommandShouldWork() throws Exception {
+        String quotaroot = "#private&user@domain";
+        String[] arguments = { "-h", "127.0.0.1", "-p", "9999", CmdType.GETMAXSTORAGEQUOTA.getCommand(), quotaroot};
+        CommandLine commandLine = ServerCmd.parseCommandLine(arguments);
+
+        expect(serverProbe.getMaxStorage(quotaroot)).andReturn(Quota.UNLIMITED);
+
+        control.replay();
+        testee.executeCommandLine(commandLine);
+        control.verify();
+    }
+
+    @Test
+    public void getStorageQuotaCommandShouldWork() throws Exception {
+        String quotaroot = "#private&user@domain";
+        String[] arguments = { "-h", "127.0.0.1", "-p", "9999", CmdType.GETSTORAGEQUOTA.getCommand(), quotaroot};
+        CommandLine commandLine = ServerCmd.parseCommandLine(arguments);
+
+        expect(serverProbe.getStorageQuota(quotaroot)).andReturn(QuotaImpl.unlimited());
+
+        control.replay();
+        testee.executeCommandLine(commandLine);
+        control.verify();
+    }
+
+    @Test
+    public void getMessageCountQuotaCommandShouldWork() throws Exception {
+        String quotaroot = "#private&user@domain";
+        String[] arguments = { "-h", "127.0.0.1", "-p", "9999", CmdType.GETMESSAGECOUNTQUOTA.getCommand(), quotaroot};
+        CommandLine commandLine = ServerCmd.parseCommandLine(arguments);
+
+        expect(serverProbe.getMessageCountQuota(quotaroot)).andReturn(QuotaImpl.unlimited());
 
         control.replay();
         testee.executeCommandLine(commandLine);

--- a/container/cli/src/test/java/org/apache/james/cli/type/CmdTypeTest.java
+++ b/container/cli/src/test/java/org/apache/james/cli/type/CmdTypeTest.java
@@ -138,6 +138,61 @@ public class CmdTypeTest {
         assertThat(CmdType.lookup("deletemailbox")).isEqualTo(CmdType.DELETEMAILBOX);
     }
 
+    @Test
+    public void lookupSetDefaultMaxStorageQuotaShouldReturnEnumValue() {
+        assertThat(CmdType.lookup("setdefaultmaxstoragequota")).isEqualTo(CmdType.SETDEFAULTMAXSTORAGEQUOTA);
+    }
+
+    @Test
+    public void lookupSetDefaultMaxMessageCountQuotaShouldReturnEnumValue() {
+        assertThat(CmdType.lookup("setdefaultmaxmessagecountquota")).isEqualTo(CmdType.SETDEFAULTMAXMESSAGECOUNTQUOTA);
+    }
+
+    @Test
+    public void lookupGetDefaultMaxStorageQuotaShouldReturnEnumValue() {
+        assertThat(CmdType.lookup("getdefaultmaxstoragequota")).isEqualTo(CmdType.GETDEFAULTMAXSTORAGEQUOTA);
+    }
+
+    @Test
+    public void lookupGetDefaultMaxMessageCountQuotaShouldReturnEnumValue() {
+        assertThat(CmdType.lookup("getdefaultmaxmessagecountquota")).isEqualTo(CmdType.GETDEFAULTMAXMESSAGECOUNTQUOTA);
+    }
+
+    @Test
+    public void lookupSetMaxStorageQuotaShouldReturnEnumValue() {
+        assertThat(CmdType.lookup("setmaxstoragequota")).isEqualTo(CmdType.SETMAXSTORAGEQUOTA);
+    }
+
+    @Test
+    public void lookupSetMaxMessageCountQuotaShouldReturnEnumValue() {
+        assertThat(CmdType.lookup("setmaxmessagecountquota")).isEqualTo(CmdType.SETMAXMESSAGECOUNTQUOTA);
+    }
+
+    @Test
+    public void lookupGetMaxStorageQuotaShouldReturnEnumValue() {
+        assertThat(CmdType.lookup("getmaxstoragequota")).isEqualTo(CmdType.GETMAXSTORAGEQUOTA);
+    }
+
+    @Test
+    public void lookupGetMaxMessageCountQuotaShouldReturnEnumValue() {
+        assertThat(CmdType.lookup("getmaxmessagecountquota")).isEqualTo(CmdType.GETMAXMESSAGECOUNTQUOTA);
+    }
+
+    @Test
+    public void lookupGetStorageQuotaShouldReturnEnumValue() {
+        assertThat(CmdType.lookup("getstoragequota")).isEqualTo(CmdType.GETSTORAGEQUOTA);
+    }
+
+    @Test
+    public void lookupGetMessageCountQuotaShouldReturnEnumValue() {
+        assertThat(CmdType.lookup("getmessagecountquota")).isEqualTo(CmdType.GETMESSAGECOUNTQUOTA);
+    }
+
+    @Test
+    public void lookupGetQuotaRootShouldReturnEnumValue() {
+        assertThat(CmdType.lookup("getquotaroot")).isEqualTo(CmdType.GETQUOTAROOT);
+    }
+
     @Test 
     public void lookupEmptyStringShouldReturnNull() {
         assertThat(CmdType.lookup("")).isNull();

--- a/container/cli/src/test/java/org/apache/james/cli/utils/ValueWithUnitTest.java
+++ b/container/cli/src/test/java/org/apache/james/cli/utils/ValueWithUnitTest.java
@@ -1,0 +1,63 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.cli.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class ValueWithUnitTest {
+
+    @Test
+    public void testNoUnit() throws Exception {
+        assertThat(ValueWithUnit.parse("1024").getConvertedValue()).isEqualTo(1024);
+    }
+
+    @Test
+    public void testUnitB() throws Exception {
+        assertThat(ValueWithUnit.parse("1024B").getConvertedValue()).isEqualTo(1024);
+    }
+
+    @Test
+    public void testUnitK() throws Exception {
+        assertThat(ValueWithUnit.parse("5K").getConvertedValue()).isEqualTo(5 * 1024);
+    }
+
+    @Test
+    public void testUnitM() throws Exception {
+        assertThat(ValueWithUnit.parse("5M").getConvertedValue()).isEqualTo(5 * 1024 * 1024);
+    }
+
+    @Test
+    public void testUnitG() throws Exception {
+        assertThat(ValueWithUnit.parse("1G").getConvertedValue()).isEqualTo(1024 * 1024 * 1024);
+    }
+
+    @Test(expected = Exception.class)
+    public void testBadUnit() throws Exception {
+        ValueWithUnit.parse("42T");
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void testWrongNumber() throws Exception {
+        ValueWithUnit.parse("42RG");
+    }
+
+}

--- a/container/cli/src/test/java/org/apache/james/cli/utils/ValueWithUnitTest.java
+++ b/container/cli/src/test/java/org/apache/james/cli/utils/ValueWithUnitTest.java
@@ -21,6 +21,7 @@ package org.apache.james.cli.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.apache.james.mailbox.model.Quota;
 import org.junit.Test;
 
 public class ValueWithUnitTest {
@@ -48,6 +49,16 @@ public class ValueWithUnitTest {
     @Test
     public void testUnitG() throws Exception {
         assertThat(ValueWithUnit.parse("1G").getConvertedValue()).isEqualTo(1024 * 1024 * 1024);
+    }
+
+    @Test
+    public void testUnknown() throws Exception {
+        assertThat(ValueWithUnit.parse("unknown").getConvertedValue()).isEqualTo(Quota.UNKNOWN);
+    }
+
+    @Test
+    public void testUnlimited() throws Exception {
+        assertThat(ValueWithUnit.parse("unlimited").getConvertedValue()).isEqualTo(Quota.UNLIMITED);
     }
 
     @Test(expected = Exception.class)

--- a/container/mailbox-adapter/src/main/java/org/apache/james/adapter/mailbox/QuotaManagement.java
+++ b/container/mailbox-adapter/src/main/java/org/apache/james/adapter/mailbox/QuotaManagement.java
@@ -1,0 +1,106 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.adapter.mailbox;
+
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.Quota;
+import org.apache.james.mailbox.model.QuotaRoot;
+import org.apache.james.mailbox.quota.MaxQuotaManager;
+import org.apache.james.mailbox.quota.QuotaManager;
+import org.apache.james.mailbox.quota.QuotaRootResolver;
+import org.apache.james.mailbox.store.quota.QuotaRootImpl;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+public class QuotaManagement implements QuotaManagementMBean {
+
+    private QuotaManager quotaManager;
+    private MaxQuotaManager maxQuotaManager;
+    private QuotaRootResolver quotaRootResolver;
+
+    public void setQuotaManager(QuotaManager quotaManager) {
+        this.quotaManager = quotaManager;
+    }
+
+    public void setMaxQuotaManager(MaxQuotaManager maxQuotaManager) {
+        this.maxQuotaManager = maxQuotaManager;
+    }
+
+    public void setQuotaRootResolver(QuotaRootResolver quotaRootResolver) {
+        this.quotaRootResolver = quotaRootResolver;
+    }
+
+    @Override
+    public QuotaRoot getQuotaRoot(String namespace, String user, String name) throws MailboxException {
+        return quotaRootResolver.getQuotaRoot(new MailboxPath(namespace, user, name));
+    }
+
+    @Override
+    public long getMaxMessageCount(String quotaRoot) throws MailboxException {
+        return maxQuotaManager.getMaxMessage(quotaRootResolver.createQuotaRoot(quotaRoot));
+    }
+
+    @Override
+    public long getMaxStorage(String quotaRoot) throws MailboxException {
+        return maxQuotaManager.getMaxStorage(quotaRootResolver.createQuotaRoot(quotaRoot));
+    }
+
+    @Override
+    public long getDefaultMaxMessageCount() throws MailboxException {
+        return maxQuotaManager.getDefaultMaxMessage();
+    }
+
+    @Override
+    public long getDefaultMaxStorage() throws MailboxException {
+        return maxQuotaManager.getDefaultMaxStorage();
+    }
+
+    @Override
+    public void setMaxMessageCount(String quotaRoot, long maxMessageCount) throws MailboxException {
+        maxQuotaManager.setMaxMessage(quotaRootResolver.createQuotaRoot(quotaRoot), maxMessageCount);
+    }
+
+    @Override
+    public void setMaxStorage(String quotaRoot, long maxSize) throws MailboxException {
+        maxQuotaManager.setMaxStorage(quotaRootResolver.createQuotaRoot(quotaRoot), maxSize);
+    }
+
+    @Override
+    public void setDefaultMaxMessageCount(long maxDefaultMessageCount) throws MailboxException {
+        maxQuotaManager.setDefaultMaxMessage(maxDefaultMessageCount);
+    }
+
+    @Override
+    public void setDefaultMaxStorage(long maxDefaultSize) throws MailboxException {
+        maxQuotaManager.setDefaultMaxStorage(maxDefaultSize);
+    }
+
+    @Override
+    public Quota getMessageCountQuota(String quotaRoot) throws MailboxException {
+        return quotaManager.getMessageQuota(quotaRootResolver.createQuotaRoot(quotaRoot));
+    }
+
+    @Override
+    public Quota getStorageQuota(String quotaRoot) throws MailboxException {
+        return quotaManager.getStorageQuota(quotaRootResolver.createQuotaRoot(quotaRoot));
+    }
+}

--- a/container/mailbox-adapter/src/main/java/org/apache/james/adapter/mailbox/QuotaManagementMBean.java
+++ b/container/mailbox-adapter/src/main/java/org/apache/james/adapter/mailbox/QuotaManagementMBean.java
@@ -1,0 +1,48 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.adapter.mailbox;
+
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.Quota;
+import org.apache.james.mailbox.model.QuotaRoot;
+
+public interface QuotaManagementMBean {
+    QuotaRoot getQuotaRoot(String namespace, String user, String name) throws MailboxException;
+
+    Quota getMessageCountQuota(String quotaRoot) throws MailboxException;
+
+    Quota getStorageQuota(String quotaRoot) throws MailboxException;
+
+    long getMaxMessageCount(String quotaRoot) throws MailboxException;
+
+    long getMaxStorage(String quotaRoot) throws MailboxException;
+
+    long getDefaultMaxMessageCount() throws MailboxException;
+
+    long getDefaultMaxStorage() throws MailboxException;
+
+    void setMaxMessageCount(String quotaRoot, long maxMessageCount) throws MailboxException;
+
+    void setMaxStorage(String quotaRoot, long maxSize) throws MailboxException;
+
+    void setDefaultMaxMessageCount(long maxDefaultMessageCount) throws MailboxException;
+
+    void setDefaultMaxStorage(long maxDefaultSize) throws MailboxException;
+}

--- a/container/spring/src/main/java/org/apache/james/container/spring/bean/factorypostprocessor/QuotaBeanFactoryPostProcessor.java
+++ b/container/spring/src/main/java/org/apache/james/container/spring/bean/factorypostprocessor/QuotaBeanFactoryPostProcessor.java
@@ -1,0 +1,119 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.container.spring.bean.factorypostprocessor;
+
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.HierarchicalConfiguration;
+import org.apache.james.container.spring.lifecycle.ConfigurationProvider;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.FatalBeanException;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+
+public class QuotaBeanFactoryPostProcessor implements BeanFactoryPostProcessor {
+
+    private static final String IN_MEMORY = "inmemory";
+    private static final String CASSANDRA = "cassandra";
+    private static final String FAKE = "fake";
+    private static final String MAX_QUOTA_MANAGER = "maxQuotaManager";
+    private static final String CURRENT_QUOTA_MANAGER = "currentQuotaManager";
+    private static final String QUOTA_MANAGER = "quotaManager";
+    private static final String QUOTA_UPDATER = "quotaUpdater";
+    private static final String PROVIDER = "provider";
+    private static final String DEFAULT = "default";
+    private static final String UPDATES = "updates";
+    private static final String QUOTA_ROOT_RESOLVER = "quotaRootResolver";
+    private static final String EVENT = "event";
+
+    @Override
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+        ConfigurationProvider confProvider = beanFactory.getBean(ConfigurationProvider.class);
+        try {
+            HierarchicalConfiguration config = confProvider.getConfiguration("quota");
+
+            String quotaRootResolver = config.configurationAt(QUOTA_ROOT_RESOLVER).getString(PROVIDER, DEFAULT);
+            String currentQuotaManager = config.configurationAt(CURRENT_QUOTA_MANAGER).getString(PROVIDER, "none");
+            String maxQuotaManager = config.configurationAt(MAX_QUOTA_MANAGER).getString(PROVIDER, FAKE);
+            String quotaManager = config.configurationAt(QUOTA_MANAGER).getString(PROVIDER, FAKE);
+            String quotaUpdater = config.configurationAt(UPDATES).getString(PROVIDER, FAKE);
+
+            BeanDefinitionRegistry registry = (BeanDefinitionRegistry) beanFactory;
+
+            registerAliasForQuotaRootResolver(quotaRootResolver, registry);
+            registerAliasForCurrentQuotaManager(currentQuotaManager, registry);
+            registerAliasForMaxQuotaManager(maxQuotaManager, registry);
+            registerAliasForQuotaManager(quotaManager, registry);
+            registerAliasForQuotaUpdater(quotaUpdater, registry);
+        } catch (ConfigurationException e) {
+            throw new FatalBeanException("Unable to configure Quota system", e);
+        }
+    }
+
+    private void registerAliasForQuotaUpdater(String quotaUpdater, BeanDefinitionRegistry registry) {
+        if (quotaUpdater.equalsIgnoreCase(EVENT)) {
+            registry.registerAlias("eventQuotaUpdater", QUOTA_UPDATER);
+        } else if (quotaUpdater.equalsIgnoreCase(FAKE)) {
+            registry.registerAlias("noQuotaUpdater", QUOTA_UPDATER);
+        } else {
+            throw new FatalBeanException("Unreadable value for Quota Updater : " + quotaUpdater);
+        }
+    }
+
+    private void registerAliasForQuotaManager(String quotaManager, BeanDefinitionRegistry registry) {
+        if (quotaManager.equalsIgnoreCase(FAKE)) {
+            registry.registerAlias("noQuotaManager", QUOTA_MANAGER);
+        } else if (quotaManager.equalsIgnoreCase("store")) {
+            registry.registerAlias("storeQuotaManager", QUOTA_MANAGER);
+        } else {
+            throw new FatalBeanException("Unreadable value for Quota Manager : " + quotaManager);
+        }
+    }
+
+    private void registerAliasForMaxQuotaManager(String maxQuotaManager, BeanDefinitionRegistry registry) {
+        if (maxQuotaManager.equalsIgnoreCase(FAKE)) {
+            registry.registerAlias("noMaxQuotaManager", MAX_QUOTA_MANAGER);
+        } else if (maxQuotaManager.equalsIgnoreCase(IN_MEMORY)) {
+            registry.registerAlias("inMemoryMaxQuotaManager", MAX_QUOTA_MANAGER);
+        } else if (maxQuotaManager.equalsIgnoreCase(CASSANDRA)) {
+            registry.registerAlias("cassandraMaxQuotaManager", MAX_QUOTA_MANAGER);
+        } else {
+            throw new FatalBeanException("Unreadable value for Max Quota Manager : " + maxQuotaManager);
+        }
+    }
+
+    private void registerAliasForCurrentQuotaManager(String currentQuotaManager, BeanDefinitionRegistry registry) {
+        if (currentQuotaManager.equalsIgnoreCase(IN_MEMORY)) {
+            registry.registerAlias("inMemoryCurrentQuotaManager", CURRENT_QUOTA_MANAGER);
+        } else if (currentQuotaManager.equalsIgnoreCase(CASSANDRA)) {
+            registry.registerAlias("cassandraCurrentQuotaManager", CURRENT_QUOTA_MANAGER);
+        } else if (! currentQuotaManager.equalsIgnoreCase("none")) {
+            throw new FatalBeanException("Unreadable value for Current Quota Manager : " + currentQuotaManager);
+        }
+    }
+
+    private void registerAliasForQuotaRootResolver(String quotaRootResolver, BeanDefinitionRegistry registry) {
+        if (quotaRootResolver.equals(DEFAULT)) {
+            registry.registerAlias("defaultQuotaRootResolver", QUOTA_ROOT_RESOLVER);
+        } else {
+            throw new FatalBeanException("Unreadable value for QUOTA ROOT resolver : " + quotaRootResolver);
+        }
+    }
+}

--- a/container/spring/src/main/java/org/apache/james/container/spring/mailbox/MaxQuotaConfigurationReader.java
+++ b/container/spring/src/main/java/org/apache/james/container/spring/mailbox/MaxQuotaConfigurationReader.java
@@ -1,0 +1,83 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.container.spring.mailbox;
+
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.HierarchicalConfiguration;
+import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.quota.MaxQuotaManager;
+import org.apache.james.mailbox.quota.QuotaRootResolver;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class MaxQuotaConfigurationReader implements Configurable {
+
+    private final MaxQuotaManager maxQuotaManager;
+    private final QuotaRootResolver quotaRootResolver;
+
+    public MaxQuotaConfigurationReader(MaxQuotaManager maxQuotaManager, QuotaRootResolver quotaRootResolver) {
+        this.maxQuotaManager = maxQuotaManager;
+        this.quotaRootResolver = quotaRootResolver;
+    }
+
+    @Override
+    public void configure(HierarchicalConfiguration config) throws ConfigurationException {
+        Long defaultMaxMessage = config.configurationAt("maxQuotaManager").getLong("defaultMaxMessage", null);
+        Long defaultMaxStorage = config.configurationAt("maxQuotaManager").getLong("defaultMaxStorage", null);
+        Map<String, Long> maxMessage = parseMaxMessageConfiguration(config, "maxMessage");
+        Map<String, Long> maxStorage = parseMaxMessageConfiguration(config, "maxMessage");
+        try {
+            configureDefaultValues(defaultMaxMessage, defaultMaxStorage);
+            configureQuotaRootSpecificValues(maxMessage, maxStorage);
+        } catch(MailboxException e) {
+            throw new ConfigurationException("Exception caught while configuring max quota manager", e);
+        }
+    }
+
+    private  Map<String, Long> parseMaxMessageConfiguration(HierarchicalConfiguration config, String entry) {
+        List<HierarchicalConfiguration> maxMessageConfiguration = config.configurationAt("maxQuotaManager").configurationsAt(entry);
+        Map<String, Long> result = new HashMap<String, Long>();
+        for (HierarchicalConfiguration conf : maxMessageConfiguration) {
+            result.put(conf.getString("quotaRoot"), conf.getLong("value"));
+        }
+        return result;
+    }
+
+    private void configureDefaultValues(Long defaultMaxMessage, Long defaultMaxStorage) throws MailboxException {
+        if (defaultMaxMessage != null) {
+            maxQuotaManager.setDefaultMaxMessage(defaultMaxMessage);
+        }
+        if (defaultMaxStorage != null) {
+            maxQuotaManager.setDefaultMaxStorage(defaultMaxStorage);
+        }
+    }
+
+    private void configureQuotaRootSpecificValues(Map<String, Long> maxMessage, Map<String, Long> maxStorage) throws MailboxException {
+        for (Map.Entry<String, Long> entry : maxMessage.entrySet()) {
+            maxQuotaManager.setMaxMessage(quotaRootResolver.createQuotaRoot(entry.getKey()), entry.getValue());
+        }
+        for (Map.Entry<String, Long> entry : maxStorage.entrySet()) {
+            maxQuotaManager.setMaxStorage(quotaRootResolver.createQuotaRoot(entry.getKey()), entry.getValue());
+        }
+    }
+}

--- a/container/spring/src/main/resources/META-INF/org/apache/james/spring-server.xml
+++ b/container/spring/src/main/resources/META-INF/org/apache/james/spring-server.xml
@@ -117,6 +117,11 @@
 
     <import resource="classpath:META-INF/spring/spring-mailbox.xml"/>
 
+    <!-- Quotas -->
+    <bean class="org.apache.james.container.spring.bean.factorypostprocessor.QuotaBeanFactoryPostProcessor"/>
+
+    <import resource="classpath:META-INF/spring/quota.xml"/>
+
     <!-- Mailbox Copier -->
     <bean id="mailboxcopier" class="org.apache.james.mailbox.copier.MailboxCopierImpl"/>
 
@@ -237,7 +242,11 @@
     <bean id="domainlistmanagement" class="org.apache.james.domainlist.lib.DomainListManagement"/>
     <bean id="mailboxmanagermanagementbean" class="org.apache.james.adapter.mailbox.MailboxManagerManagement"/>
     <bean id="mailboxcopiermanagement" class="org.apache.james.container.spring.mailbox.MailboxCopierManagement"/>
-    <bean id="quotamanagermanagement" class="org.apache.james.adapter.mailbox.QuotaManagement"/>
+    <bean id="quotamanagermanagement" class="org.apache.james.adapter.mailbox.QuotaManagement">
+        <property name="maxQuotaManager" ref="maxQuotaManager"/>
+        <property name="quotaRootResolver" ref="quotaRootResolver"/>
+        <property name="quotaManager" ref="quotaManager"/>
+    </bean>
     <!--
         <bean id="james23importermanagement" class="org.apache.james.container.spring.tool.James23ImporterManagement" />
     -->

--- a/container/spring/src/main/resources/META-INF/org/apache/james/spring-server.xml
+++ b/container/spring/src/main/resources/META-INF/org/apache/james/spring-server.xml
@@ -221,12 +221,13 @@
                           <entry key="org.apache.james:type=component,name=james23importer" value-ref="james23importermanagement"/>
                 -->
                 <entry key="org.apache.james:type=container,name=logprovider" value-ref="logprovider"/>
+                <entry key="org.apache.james:type=component,name=quotamanagerbean" value-ref="quotamanagermanagement"/>
             </map>
         </property>
         <property name="assembler">
             <bean class="org.springframework.jmx.export.assembler.InterfaceBasedMBeanInfoAssembler">
                 <property name="managedInterfaces"
-                          value="org.apache.james.fetchmail.FetchSchedulerMBean,org.apache.james.domainlist.api.DomainListManagementMBean,org.apache.james.dnsservice.api.DNSServiceMBean,org.apache.james.rrt.api.RecipientRewriteTableManagementMBean,org.apache.james.user.api.UsersRepositoryManagementMBean,org.apache.james.adapter.mailbox.MailboxManagerManagementMBean,org.apache.james.container.spring.mailbox.MailboxCopierManagementMBean,org.apache.james.mailetcontainer.api.jmx.MailSpoolerMBean,org.apache.james.container.spring.lifecycle.LogProviderManagementMBean"/>
+                          value="org.apache.james.fetchmail.FetchSchedulerMBean,org.apache.james.domainlist.api.DomainListManagementMBean,org.apache.james.dnsservice.api.DNSServiceMBean,org.apache.james.rrt.api.RecipientRewriteTableManagementMBean,org.apache.james.user.api.UsersRepositoryManagementMBean,org.apache.james.adapter.mailbox.MailboxManagerManagementMBean,org.apache.james.container.spring.mailbox.MailboxCopierManagementMBean,org.apache.james.mailetcontainer.api.jmx.MailSpoolerMBean,org.apache.james.container.spring.lifecycle.LogProviderManagementMBean,org.apache.james.adapter.mailbox.QuotaManagementMBean"/>
             </bean>
         </property>
     </bean>
@@ -236,6 +237,7 @@
     <bean id="domainlistmanagement" class="org.apache.james.domainlist.lib.DomainListManagement"/>
     <bean id="mailboxmanagermanagementbean" class="org.apache.james.adapter.mailbox.MailboxManagerManagement"/>
     <bean id="mailboxcopiermanagement" class="org.apache.james.container.spring.mailbox.MailboxCopierManagement"/>
+    <bean id="quotamanagermanagement" class="org.apache.james.adapter.mailbox.QuotaManagement"/>
     <!--
         <bean id="james23importermanagement" class="org.apache.james.container.spring.tool.James23ImporterManagement" />
     -->

--- a/container/spring/src/main/resources/META-INF/org/apache/james/spring-server.xml
+++ b/container/spring/src/main/resources/META-INF/org/apache/james/spring-server.xml
@@ -122,6 +122,11 @@
 
     <import resource="classpath:META-INF/spring/quota.xml"/>
 
+    <bean id="quota" class="org.apache.james.container.spring.mailbox.MaxQuotaConfigurationReader">
+        <constructor-arg index="0" ref="maxQuotaManager"/>
+        <constructor-arg index="1" ref="quotaRootResolver"/>
+    </bean>
+
     <!-- Mailbox Copier -->
     <bean id="mailboxcopier" class="org.apache.james.mailbox.copier.MailboxCopierImpl"/>
 

--- a/mailet/mailets/src/main/java/org/apache/james/transport/matchers/IsOverQuota.java
+++ b/mailet/mailets/src/main/java/org/apache/james/transport/matchers/IsOverQuota.java
@@ -1,0 +1,63 @@
+package org.apache.james.transport.matchers;
+
+import org.apache.james.mailbox.MailboxManager;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.QuotaRoot;
+import org.apache.james.mailbox.quota.QuotaManager;
+import org.apache.james.mailbox.quota.QuotaRootResolver;
+import org.apache.mailet.Mail;
+import org.apache.mailet.MailAddress;
+import org.apache.mailet.base.GenericMatcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.mail.MessagingException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class IsOverQuota extends GenericMatcher {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(IsOverQuota.class);
+
+    private QuotaRootResolver quotaRootResolver;
+    private QuotaManager quotaManager;
+    private MailboxManager mailboxManager;
+
+    @Inject
+    public void setQuotaRootResolver(QuotaRootResolver quotaRootResolver) {
+        this.quotaRootResolver = quotaRootResolver;
+    }
+
+    @Inject
+    public void setQuotaManager(QuotaManager quotaManager) {
+        this.quotaManager = quotaManager;
+    }
+
+    @Inject
+    public void setMailboxManager(MailboxManager mailboxManager) {
+        this.mailboxManager = mailboxManager;
+    }
+
+    @Override
+    public Collection<MailAddress> match(Mail mail) throws MessagingException {
+        try {
+            List<MailAddress> result = new ArrayList<MailAddress>();
+            for (MailAddress mailAddress : mail.getRecipients()) {
+                MailboxSession mailboxSession = mailboxManager.createSystemSession(mailAddress.getLocalPart(), LOGGER);
+                MailboxPath mailboxPath = MailboxPath.inbox(mailboxSession);
+                QuotaRoot quotaRoot = quotaRootResolver.getQuotaRoot(mailboxPath);
+                if (quotaManager.getMessageQuota(quotaRoot).isOverQuota() &&
+                    quotaManager.getStorageQuota(quotaRoot).isOverQuota()) {
+                    result.add(mailAddress);
+                }
+            }
+            return result;
+        } catch(MailboxException e) {
+            throw new MessagingException("Exception while checking quotas", e);
+        }
+    }
+}

--- a/protocols/protocols-imap4/src/main/resources/META-INF/spring/imapserver-context.xml
+++ b/protocols/protocols-imap4/src/main/resources/META-INF/spring/imapserver-context.xml
@@ -34,10 +34,12 @@
         <constructor-arg index="1" ref="subscriptionManager"/>
         <!-- The mailboxTyper -->
         <constructor-arg index="2" value="#{null}"/>
+        <constructor-arg index="3" ref="quotaManager"/>
+        <constructor-arg index="4" ref="quotaRootResolver"/>
         <!-- The idleKeepAlive -->
-        <constructor-arg index="3" value="120"/>
+        <constructor-arg index="5" value="120"/>
         <!-- The list of disabled capabilities -->
-        <constructor-arg index="4">
+        <constructor-arg index="6">
             <set>
                 <value>ACL</value>
                 <value>MOVE</value>


### PR DESCRIPTION
RFC-2087 Quota full integration in James

In my work, I : 

 - Proposed a matcher for over quota mailboxes, relying on QuotaManager API. This implementation is performant as quota does not need to be recalculated on each mail processed. Think of this mailet as a way to respond to the sender "Hello, message can not be delivered to X as its mailbox is over quota".

 - Integration for PROTOCOLS-108 PR : RFC-2087 implementation of quota commands. An IMAP client can now query JAMES for its available message count and storage.

 - CLI integration. You can query the quota's API from CLI and get the quotas for a QUOTA ROOT, defaul policies, max policies, and so on.

 - Spring integration : Just like mailbox, you can directly from quota.xml configuration file select the components you want, and configure max quota manager (quota limits default and per quota root )

Related PRs : MAILBOX-64, MPT-26, PROTOCOLS-108